### PR TITLE
Bugfix/bbx 1477 fix pulse listing query parameters

### DIFF
--- a/src/SPT-Pulse/969_SPT-identify-listing.js
+++ b/src/SPT-Pulse/969_SPT-identify-listing.js
@@ -1,0 +1,34 @@
+if (
+    b.event_name.toLowerCase() === "list" ||
+    b.event_name.toLowerCase() === "list_tile" ||
+    b.event_name.toLowerCase() === "list_map" ||
+    b.event_name.toLowerCase() === "search_result_list" ||
+    b.event_name.toLowerCase() === "search_result_img" ||
+    b.event_name.toLowerCase() === "llp_list" ||
+    b.event_name.toLowerCase() === "llp_img" ||
+    b.event_name.toLowerCase().indexOf("more_ads_from_user_search_result_list") > -1
+) {
+    b.spt_is_listing = "true";
+    try {
+        b.spt_custom = JSON.stringify({
+            name: "Listing viewed",
+            object: {
+                location: {
+                    addressCountry: b.region_level_1,
+                },
+                filters: {
+                    query: b["dom.query_string"],
+                    sorting: b.map_sort_param(b["qp.sort"], b.vertical_id),
+                    numResults: b["qp.rows"] ? b["qp.rows"] : "25",
+                    publisherType: b.map_is_private(b["qp.ISPRIVATE"]),
+                    adType:
+                        b.category_level_id_1 === "131" || b.category_level_id_1 === "132" || b.category_level_id_1 === "16" || b.category_level_id_1 === "32" ? "rent" : "sell",
+                    postalCode: b.map_post_code(),
+                    region: b.map_region(b.region_level_1, b.region_level_2, b.region_level_3),
+                },
+            },
+        });
+    } catch (e) {
+        // ignore
+    }
+}

--- a/src/SPT-Pulse/969_SPT-identify-listing.js
+++ b/src/SPT-Pulse/969_SPT-identify-listing.js
@@ -1,3 +1,21 @@
+function urlGetParameters() {
+    var queryAndFragment = window.location.search + (window.location.hash + "").replace("#", "&");
+    var parameters = {};
+    if (utag.cfg.lowerqp) {
+        queryAndFragment = queryAndFragment.toLowerCase();
+    }
+    if (queryAndFragment.length > 1) {
+        var keyValueArray = queryAndFragment.substring(1).split("&");
+        for (queryAndFragment = 0; queryAndFragment < keyValueArray.length; queryAndFragment++) {
+            var keyAndValue = keyValueArray[queryAndFragment].split("=");
+            if (keyAndValue.length > 1) {
+                parameters[keyAndValue[0]] = utag.ut.decode(keyAndValue[1]);
+            }
+        }
+    }
+    return parameters;
+}
+
 if (
     b.event_name.toLowerCase() === "list" ||
     b.event_name.toLowerCase() === "list_tile" ||
@@ -10,6 +28,10 @@ if (
 ) {
     b.spt_is_listing = "true";
     try {
+        var getParams = urlGetParameters();
+        var sorting = b.map_sort_param(getParams.sort, b.vertical_id);
+        var rows = getParams.rows || "25";
+        var publisherType = b.map_is_private(getParams.ISPRIVATE);
         b.spt_custom = JSON.stringify({
             name: "Listing viewed",
             object: {
@@ -18,9 +40,9 @@ if (
                 },
                 filters: {
                     query: b["dom.query_string"],
-                    sorting: b.map_sort_param(b["qp.sort"], b.vertical_id),
-                    numResults: b["qp.rows"] ? b["qp.rows"] : "25",
-                    publisherType: b.map_is_private(b["qp.ISPRIVATE"]),
+                    sorting: sorting,
+                    numResults: rows,
+                    publisherType: publisherType,
                     adType:
                         b.category_level_id_1 === "131" || b.category_level_id_1 === "132" || b.category_level_id_1 === "16" || b.category_level_id_1 === "32" ? "rent" : "sell",
                     postalCode: b.map_post_code(),

--- a/src/SPT-Pulse/969_SPT-identify-listing.js
+++ b/src/SPT-Pulse/969_SPT-identify-listing.js
@@ -6,8 +6,8 @@ function urlGetParameters() {
     }
     if (queryAndFragment.length > 1) {
         var keyValueArray = queryAndFragment.substring(1).split("&");
-        for (queryAndFragment = 0; queryAndFragment < keyValueArray.length; queryAndFragment++) {
-            var keyAndValue = keyValueArray[queryAndFragment].split("=");
+        for (var i = 0; i < keyValueArray.length; i++) {
+            var keyAndValue = keyValueArray[i].split("=");
             if (keyAndValue.length > 1) {
                 parameters[keyAndValue[0]] = utag.ut.decode(keyAndValue[1]);
             }


### PR DESCRIPTION
extract current query from window.location instead of using the "qp" variable from tealium, because tealium only calculates qp initially when loading the page, not on client side routing, which is problematic for SPAs like BBX

https://community.tealiumiq.com/t5/Tealium-iQ-Tag-Management/Query-variable-qp-not-updated-on-Client-Side-Routing/td-p/31605