### PR TITLE
BBX-2047 the events adimage_view and adimage_view_fullscreen have bee…

### DIFF
--- a/src/SPT-Pulse/933_SPT-block_change_image_event.js
+++ b/src/SPT-Pulse/933_SPT-block_change_image_event.js
@@ -1,11 +1,7 @@
 var client = (b.client || "").toLowerCase();
 if (
     a === "view" &&
-    ((client === "bbx" && b.event_name === "adimage_view") ||
-        (client === "bbx" && b.event_name === "adimage_view_fullscreen") ||
-        (client === "desktop" && b.event_name === "ad_img") ||
-        (client === "mweb" && b.event_name === "adimg") ||
-        (client === "mweb" && b.event_name === "view_image"))
+    ((client === "desktop" && b.event_name === "ad_img") || (client === "mweb" && b.event_name === "adimg") || (client === "mweb" && b.event_name === "view_image"))
 ) {
     // do not track change image events in Pulse
     return false;


### PR DESCRIPTION
…n removed from bbx, therefore they can be removed from the pulse event filter