### PR TITLE
BBX-2423 removed wrong origin 

### DIFF
--- a/src/SPT-Pulse/840_SPT_phone_number_called.js
+++ b/src/SPT-Pulse/840_SPT_phone_number_called.js
@@ -37,7 +37,6 @@ if (client === "desktop" || client === "mweb" || client === "bbx") {
                         category: eventDefaults && eventDefaults.object ? eventDefaults.object.category : undefined,
                         price: b.price,
                     },
-                    origin: eventDefaults.object,
                 };
                 var tempTracker = tracker.clone();
                 tempTracker.builders.object = {};

--- a/src/SPT-Pulse/930_SPT_show_phone_number.js
+++ b/src/SPT-Pulse/930_SPT_show_phone_number.js
@@ -34,7 +34,6 @@ if (client === "desktop" || client === "mweb" || client === "bbx") {
                             },
                         },
                     },
-                    origin: eventDefaults.object,
                 };
                 var tempTracker = tracker.clone();
                 tempTracker.builders.object = {};

--- a/src/SPT-Pulse/970_SPT-payment_delivery_choose_parcel_size.js
+++ b/src/SPT-Pulse/970_SPT-payment_delivery_choose_parcel_size.js
@@ -24,7 +24,6 @@ if (client === "desktop" || client === "mweb" || client === "bbx") {
                         adId: b.ad_id,
                         publisherType: isPrivate ? "private" : "pro",
                     },
-                    origin: eventDefaults.object,
                 };
                 var tempTracker = tracker.clone();
                 tempTracker.builders.object = {};


### PR DESCRIPTION
for events "Ad phone number called", "Ad phone number displayed" and "Payment&Delivery parcel size chosen"

removing it will use the default origin, which is the url of the previous view event